### PR TITLE
Refine macOS Qt plugin fix with environment re-exec strategy

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,42 +70,96 @@ def main():
 
         # Attempt to fix missing plugin issue on macOS
         if sys.platform == 'darwin':
-            logging.info("Checking Qt plugins configuration for macOS...")
+            # Check if we have already restarted to apply environment variables
+            if not os.environ.get('OPEN_RAZER_RESTARTED'):
+                logging.info("Checking Qt plugins configuration for macOS (Pre-launch)...")
 
-            # Method 1: Ask QLibraryInfo
-            plugin_path = QLibraryInfo.location(QLibraryInfo.PluginsPath)
-            logging.info(f"QLibraryInfo.PluginsPath: {plugin_path}")
+                # Method 1: Ask QLibraryInfo
+                plugin_path = QLibraryInfo.location(QLibraryInfo.PluginsPath)
+                logging.info(f"QLibraryInfo.PluginsPath: {plugin_path}")
 
-            # Method 2: Check relative to PyQt5 package (often robust in venvs)
-            pkg_path = os.path.dirname(PyQt5.__file__)
-            logging.info(f"PyQt5 package path: {pkg_path}")
+                # Method 2: Check relative to PyQt5 package (often robust in venvs)
+                pkg_path = os.path.dirname(PyQt5.__file__)
+                logging.info(f"PyQt5 package path: {pkg_path}")
 
-            potential_paths = []
-            if plugin_path:
-                potential_paths.append(plugin_path)
+                potential_paths = []
+                if plugin_path:
+                    potential_paths.append(plugin_path)
 
-            # Common layouts
-            potential_paths.extend([
-                os.path.join(pkg_path, 'Qt5', 'plugins'),
-                os.path.join(pkg_path, 'Qt', 'plugins'),
-                os.path.join(pkg_path, 'plugins'),
-            ])
+                # Common layouts
+                potential_paths.extend([
+                    os.path.join(pkg_path, 'Qt5', 'plugins'),
+                    os.path.join(pkg_path, 'Qt', 'plugins'),
+                    os.path.join(pkg_path, 'plugins'),
+                ])
 
-            found_plugin_path = None
-            for p in potential_paths:
-                cocoa_path = os.path.join(p, 'platforms', 'libqcocoa.dylib')
-                if os.path.exists(cocoa_path):
-                    logging.info(f"Found 'libqcocoa.dylib' at: {cocoa_path}")
-                    found_plugin_path = p
-                    break
-                else:
-                    logging.debug(f"Checked for cocoa plugin at {cocoa_path} (not found)")
+                found_plugin_dir = None
+                found_platforms_dir = None
 
-            if found_plugin_path:
-                logging.info(f"Setting QT_QPA_PLATFORM_PLUGIN_PATH to: {found_plugin_path}")
-                os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = found_plugin_path
+                for p in potential_paths:
+                    cocoa_path = os.path.join(p, 'platforms', 'libqcocoa.dylib')
+                    if os.path.exists(cocoa_path):
+                        logging.info(f"Found 'libqcocoa.dylib' at: {cocoa_path}")
+                        found_plugin_dir = p
+                        found_platforms_dir = os.path.join(p, 'platforms')
+                        break
+                    else:
+                        logging.debug(f"Checked for cocoa plugin at {cocoa_path} (not found)")
+
+                # Try to locate the 'lib' directory (Qt Frameworks)
+                # It is usually parallel to 'plugins' or 'bin' in 'Qt5' folder.
+                # e.g. .../PyQt5/Qt5/lib
+                found_lib_dir = None
+                if found_plugin_dir:
+                    # found_plugin_dir is usually .../Qt5/plugins
+                    # Try ../lib
+                    potential_lib = os.path.join(os.path.dirname(found_plugin_dir), 'lib')
+                    if os.path.exists(potential_lib):
+                        found_lib_dir = potential_lib
+                        logging.info(f"Found Qt lib directory at: {found_lib_dir}")
+
+                env_updates = {}
+
+                if found_plugin_dir:
+                    logging.info(f"Setting QT_PLUGIN_PATH to: {found_plugin_dir}")
+                    env_updates['QT_PLUGIN_PATH'] = found_plugin_dir
+
+                if found_platforms_dir:
+                    logging.info(f"Setting QT_QPA_PLATFORM_PLUGIN_PATH to: {found_platforms_dir}")
+                    env_updates['QT_QPA_PLATFORM_PLUGIN_PATH'] = found_platforms_dir
+
+                if found_lib_dir:
+                    current_dyld = os.environ.get('DYLD_LIBRARY_PATH', '')
+                    new_dyld = f"{found_lib_dir}:{current_dyld}" if current_dyld else found_lib_dir
+                    logging.info(f"Updating DYLD_LIBRARY_PATH with: {found_lib_dir}")
+                    env_updates['DYLD_LIBRARY_PATH'] = new_dyld
+
+                    current_framework = os.environ.get('DYLD_FRAMEWORK_PATH', '')
+                    new_framework = f"{found_lib_dir}:{current_framework}" if current_framework else found_lib_dir
+                    logging.info(f"Updating DYLD_FRAMEWORK_PATH with: {found_lib_dir}")
+                    env_updates['DYLD_FRAMEWORK_PATH'] = new_framework
+
+                if env_updates:
+                    logging.info("Restarting application to apply environment variables...")
+                    env = os.environ.copy()
+                    env.update(env_updates)
+                    env['OPEN_RAZER_RESTARTED'] = '1'
+
+                    # Flush stdout/stderr before restart
+                    sys.stdout.flush()
+                    sys.stderr.flush()
+
+                    try:
+                        os.execvpe(sys.executable, [sys.executable] + sys.argv, env)
+                    except OSError as e:
+                        logging.error(f"Failed to restart application: {e}")
+                        # Fallback: try setting os.environ locally and proceed (though DYLD vars won't help for loaded libs)
+                        os.environ.update(env_updates)
             else:
-                logging.warning("Could not locate 'libqcocoa.dylib'. Application might fail to start if plugins are missing.")
+                logging.info("Environment variables applied via restart.")
+                # As a backup, add library path to CoreApplication
+                if 'QT_PLUGIN_PATH' in os.environ:
+                    QApplication.addLibraryPath(os.environ['QT_PLUGIN_PATH'])
 
         logging.info("Creating QApplication...")
         app = QApplication(sys.argv)


### PR DESCRIPTION
    - Improve detection of Qt plugins and library directories.
    - Set `QT_PLUGIN_PATH` to the plugins directory and `QT_QPA_PLATFORM_PLUGIN_PATH` to the platforms subdirectory.
    - Set `DYLD_LIBRARY_PATH` and `DYLD_FRAMEWORK_PATH` to include the Qt `lib` directory to resolve dependencies for `libqcocoa.dylib`.
    - Implement an `os.execvpe` restart mechanism to ensure environment variables are picked up by the dynamic linker (dyld) from the start of the process, solving the "cocoa plugin not found" crash.