### PR TITLE
Add debug diagnostics and robust startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The application attempts to communicate with the following devices. Functionalit
 ✅ Graphical User Interface (GUI) for device selection and effect configuration
 ✅ Sets **Static, Breathing, Wave, and Reactive** RGB effects via HID commands
 ✅ Option to reset/turn off effects
+✅ **Developer Mode**: Verbose logging and scanning of all connected Razer devices (supported or not) to aid in adding new hardware support.
 ✅ Basic application logging (`~/Library/Logs/open_razer_macos_control_app.log` or `~/open_razer_macos_control_app.log`)
 
 ---
@@ -91,10 +92,28 @@ The application attempts to communicate with the following devices. Functionalit
     ```
 6.  **Run the application**:
     ```bash
+    # Standard Mode (Logs to file only)
     python3 main.py
+
+    # Developer Mode (Verbose console logs + Lists ALL Razer devices)
+    # Use this if your device is not showing up!
+    python3 main.py --debug
     ```
 7.  **Permission issues?**
     - Accessing HID devices on macOS might require special permissions or occasionally running with `sudo python3 main.py`, though this is generally discouraged. Ensure your user has the necessary permissions first. Check System Settings -> Privacy & Security -> Input Monitoring if issues persist.
+
+---
+
+## 🔍 Diagnosing Unsupported Devices
+If your Razer device is connected but not showing up in the list:
+1. Run the application in **Debug Mode**:
+   ```bash
+   python3 main.py --debug
+   ```
+2. Check the terminal output. Look for lines starting with `Device found:`.
+   - Example: `Device found: PID=0x025A, Product='Razer BlackWidow V3 Pro Wired', Interface=0, ...`
+3. Note the **PID** (e.g., `0x025A`) of your device.
+4. Open an Issue (or create a Pull Request) with this PID and the device name so we can add support!
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -60,6 +60,17 @@ def main():
 
     setup_logging(debug_mode)
 
+    # In debug mode, scan and log devices immediately.
+    # This ensures that even if the GUI crashes (e.g. PyQt plugin issues),
+    # the user still gets the PID information they need.
+    if debug_mode:
+        logging.info("Debug mode: performing early device scan...")
+        try:
+            from razer_common import scan_razer_devices
+            scan_razer_devices(debug_mode=True)
+        except Exception as e:
+            logging.error(f"Early scan failed: {e}")
+
     try:
         logging.info("Importing UI modules...")
         from PyQt5.QtWidgets import QApplication


### PR DESCRIPTION
- Add `--debug` and `--prod` arguments to `main.py`
- Configure logging: Debug mode logs to stdout and file; Prod mode logs to file only.
- Implement early device scanning in `main.py` when in debug mode, ensuring PIDs are logged even if the GUI crashes.
- Update `scan_razer_devices` in `razer_common.py` to log all connected Razer devices (VID 0x1532).
- Update `razer_ui.py` to display guidance when no supported devices are found in debug mode.
- Add macOS Qt plugin detection and process restart mechanism to fix `libqcocoa.dylib` issues.